### PR TITLE
Add nav to first section of body

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,12 @@
   </head>
   <body class="purple-1">
     <section class="menu purple-4">
-      <h1 class="header-text">IdeaBox</h1>
+      <nav>
+        <img class="hamburger" src="assets/menu.svg" alt="menu">
+        <h1 class="header-text">IdeaBox</h1>
+        <h3>Filter Starred Ideas</h3>
+        <button>Show Starred Ideas</button>
+      </nav>
     </section>
     <main class="ideas">
       <section class="idea-form purple-2">
@@ -28,19 +33,42 @@
             <img class="banner-star" src="assets/star-active.svg" alt="card-star-icon">
             <img class="banner-x" src="assets/delete.svg" alt="card-delete-icon">
           </section>
-          <h2>Idea title</h2>
-          <h2>Idea body</h2>
-          <h3>Comment</h3>
+          <section class="card-content">
+            <h2>Idea title</h2>
+            <h2>Idea body</h2>
+          </section>
+          <section class="card-footer">
+            <img src="assets/comment.svg" alt="icon-comment">
+            <h3 class="comment-text">Comment</h3>
+          </section>
         </article>
         <article class="card">
-          <h2>Idea title</h2>
-          <h2>Idea body</h2>
-          <h3>Comment</h3>
+          <section class="card-banner-top">
+            <img class="banner-star" src="assets/star-active.svg" alt="card-star-icon">
+            <img class="banner-x" src="assets/delete.svg" alt="card-delete-icon">
+          </section>
+          <section class="card-content">
+            <h2>Idea title</h2>
+            <h2>Idea body</h2>
+          </section>
+          <section class="card-footer">
+            <img id="icon-comment" src="assets/comment.svg" alt="icon-comment">
+            <h3 class="comment-text">Comment</h3>
+          </section>
         </article>
         <article class="card">
-          <h2>Idea title</h2>
-          <h2>Idea body</h2>
-          <h3>Comment</h3>
+          <section class="card-banner-top">
+            <img class="banner-star" src="assets/star-active.svg" alt="card-star-icon">
+            <img class="banner-x" src="assets/delete.svg" alt="card-delete-icon">
+          </section>
+          <section class="card-content">
+            <h2>Idea title</h2>
+            <h2>Idea body</h2>
+          </section>
+          <section class="card-footer">
+            <img src="assets/comment.svg" alt="icon-comment">
+            <h3 class="comment-text">Comment</h3>
+          </section>
         </article>
       </section>
     </main>

--- a/styles.css
+++ b/styles.css
@@ -54,6 +54,18 @@ body {
 }
 
 /*=== main section ===*/
+
+.hamburger {
+  width: 35%;
+  height: 90%;
+}
+
+nav {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: 1fr 1fr 1fr;
+}
+
 .form-text {
   text-align: left;
   padding: 3% 0 1% 0;
@@ -109,7 +121,9 @@ body {
 }
 
 .card img {
-  width: 10%;
+  width: 7%;
+  padding-left: 2%;
+  padding-right: 2%;
 }
 
 .card-banner-top {
@@ -119,6 +133,22 @@ body {
   background-color: #1F1F3D;
 }
 
+.card-footer {
+  display: flex;
+  justify-content:flex-start;
+  background-color: #5357A5;
+  color: #E9E9F3;
+}
+
+.comment-text {
+  margin-top: 0;
+  display: flex;
+  align-self: center;
+}
+
+/* #icon-comment {
+
+} */
 /* .banner-star {
   display: flex;
   justify-content: space-between; */


### PR DESCRIPTION
What’s this PR do?

  Where should the reviewer start?  
- Start with the first section in the body to see nav's child elements, which include an image and some text

How should this be manually tested?  
- This can be tested by opening index.html in the browser and confirming that the hamburger icon exists to the left of "IdeaBox."  The rest of the text in this section is not yet properly formatted/positioned.

Any background context you want to provide?  
- N/A

What are the relevant tickets?  
- N/A

Screenshots (if appropriate)

![IdeaBox-nav](https://user-images.githubusercontent.com/62262404/88329857-cef69680-cce7-11ea-9200-fb0049c21bf5.png)

  Questions: 
- How can we position the other text so that it does not display in the main view?